### PR TITLE
fix: module loading in a webpack/cjs environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@types/bytes": "^3.1.4",
         "@types/cross-spawn": "^6.0.2",
         "@types/fs-extra": "^11.0.4",
-        "@types/node": "^22.7.0",
+        "@types/node": "^22.7.5",
         "@types/proper-lockfile": "^4.1.4",
         "@types/semver": "^7.5.8",
         "@types/validate-npm-package-name": "^4.0.2",
@@ -4212,11 +4212,10 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.0.tgz",
-      "integrity": "sha512-MOdOibwBs6KW1vfqz2uKMlxq5xAfAZ98SZjO8e3XnAbFnTJtAspqhWk7hrdSAs9/Y14ZWMiy7/MxMUzAOadYEw==",
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "@types/bytes": "^3.1.4",
     "@types/cross-spawn": "^6.0.2",
     "@types/fs-extra": "^11.0.4",
-    "@types/node": "^22.7.0",
+    "@types/node": "^22.7.5",
     "@types/proper-lockfile": "^4.1.4",
     "@types/semver": "^7.5.8",
     "@types/validate-npm-package-name": "^4.0.2",

--- a/src/bindings/utils/compileLLamaCpp.ts
+++ b/src/bindings/utils/compileLLamaCpp.ts
@@ -382,44 +382,54 @@ function getPrebuiltBinariesPackageDirectoryForBuildOptions(buildOptions: BuildO
         }
     }
 
+    async function loadModule(modulePath: string) {
+        if (typeof require !== "undefined" && typeof module !== "undefined" && module.exports) {
+            // CommonJS
+            return require(modulePath);
+        } else {
+            // ESM
+            return import(modulePath);
+        }
+    }
+
     if (buildOptions.platform === "mac") {
         if (buildOptions.arch === "arm64" && buildOptions.gpu === "metal")
             // @ts-ignore
-            return getBinariesPathFromModules(() => import("@node-llama-cpp/mac-arm64-metal"));
+            return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/mac-arm64-metal"));
         else if (buildOptions.arch === "x64" && buildOptions.gpu === false)
             // @ts-ignore
-            return getBinariesPathFromModules(() => import("@node-llama-cpp/mac-x64"));
+            return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/mac-x64"));
     } else if (buildOptions.platform === "linux") {
         if (buildOptions.arch === "x64") {
             if (buildOptions.gpu === "cuda")
                 // @ts-ignore
-                return getBinariesPathFromModules(() => import("@node-llama-cpp/linux-x64-cuda"));
+                return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/linux-x64-cuda"));
             else if (buildOptions.gpu === "vulkan")
                 // @ts-ignore
-                return getBinariesPathFromModules(() => import("@node-llama-cpp/linux-x64-vulkan"));
+                return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/linux-x64-vulkan"));
             else if (buildOptions.gpu === false)
                 // @ts-ignore
-                return getBinariesPathFromModules(() => import("@node-llama-cpp/linux-x64"));
+                return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/linux-x64"));
         } else if (buildOptions.arch === "arm64")
             // @ts-ignore
-            return getBinariesPathFromModules(() => import("@node-llama-cpp/linux-arm64"));
+            return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/linux-arm64"));
         else if (buildOptions.arch === "arm")
             // @ts-ignore
-            return getBinariesPathFromModules(() => import("@node-llama-cpp/linux-armv7l"));
+            return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/linux-armv7l"));
     } else if (buildOptions.platform === "win") {
         if (buildOptions.arch === "x64") {
             if (buildOptions.gpu === "cuda")
                 // @ts-ignore
-                return getBinariesPathFromModules(() => import("@node-llama-cpp/win-x64-cuda"));
+                return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/win-x64-cuda"));
             else if (buildOptions.gpu === "vulkan")
                 // @ts-ignore
-                return getBinariesPathFromModules(() => import("@node-llama-cpp/win-x64-vulkan"));
+                return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/win-x64-vulkan"));
             else if (buildOptions.gpu === false)
                 // @ts-ignore
-                return getBinariesPathFromModules(() => import("@node-llama-cpp/win-x64"));
+                return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/win-x64"));
         } else if (buildOptions.arch === "arm64")
             // @ts-ignore
-            return getBinariesPathFromModules(() => import("@node-llama-cpp/win-arm64"));
+            return getBinariesPathFromModules(() => loadModule("@node-llama-cpp/win-arm64"));
     }
 
     return null;


### PR DESCRIPTION
### Description of change
Error when use node-llama-cpp with webpack/commonjs
node-llama-cpp is imported using `await import('node-llama-cpp')` in Typescript

```
ERROR in ./node_modules/node-llama-cpp/dist/bindings/utils/compileLLamaCpp.js 270:52-85
Module not found: Error: Can't resolve '@node-llama-cpp/mac-x64'
```

Modules that do not exist will result in errors when build with webpack

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply eslint formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits and pull request title follow conventions explained in [pull request guidelines](https://node-llama-cpp.withcat.ai/guide/contributing) (PRs that do not follow this convention will not be merged)
